### PR TITLE
fixed tokio example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ syn = { version = "1.0.85", features = [ "full" ] }
 reqwest = { version = "0.11", features = ["blocking"] }
 ping = "0.3.0"
 regex = "1"
-tokio = { version = "1.15.0", features = ["rt", "macros"], optional = true }
 users = "0.11.0"
 sysinfo = "0.23.5"
 byte-unit = "4.0.13"
@@ -28,4 +27,6 @@ num_cpus = "1.13.1"
 
 [features]
 ign-msg = []
-example = ["tokio"]
+
+[dev-dependencies]
+tokio = { version = "1.15.0", features = ["rt", "macros"] }

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,9 +1,12 @@
-#[cfg(feature = "example")]
+use tokio;
+
 #[tokio::main]
 async fn main() {}
 
-#[cfg(feature = "example")]
-#[tokio::test]
-async fn my_test() {
-    assert!(true);
+#[cfg(test)]
+mod tokio_tests {
+    #[tokio::test]
+    async fn my_test() {
+        assert!(true);
+    }
 }


### PR DESCRIPTION
moved the tokio dependencies to dev-dependencies since you only need it for running tests and not in the compiled lib. 
and made the tokio example the same as all the other examples layout wise.
added the tokio dependencies to the tokio example.