### PR TITLE
Fix compilation with `--no-default-features`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@ use std::net::TcpStream;
 
 use proc_macro::TokenStream;
 #[cfg(any(feature = "resource", feature = "icmp"))]
-use proc_macro_error::{abort_call_site, proc_macro_error};
+use proc_macro_error::abort_call_site;
+use proc_macro_error::proc_macro_error;
 use syn::{parse_macro_input, ItemFn, ItemMod};
 #[cfg(feature = "resource")]
 use sysinfo::SystemExt;


### PR DESCRIPTION
`#[proc_macro_error]` is also used if the default features are disabled.

----

This is a regression from 0.9.4. Can you get a new release out with this? Thanks :)