### PR TITLE
fix: env macro multiline support

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -257,3 +257,58 @@ pub(crate) fn mod_macro(
         abort_call_site!("should use on mod with context")
     }
 }
+
+/// Sanitize the attribute string to remove any leading or trailing whitespace
+/// and split the string into an iterator of individual environment variable names.
+pub fn sanitize_env_vars_attr(attr_str: &str) -> impl Iterator<Item=&str> {
+    attr_str.split(',').map(str::trim)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_env_vars_attr;
+
+    #[test]
+    fn sanitize_single_env_var() {
+        //* Given
+        let env_var = "FOO";
+
+        let attr_str = env_var.to_string();
+
+        //* When
+        let result = sanitize_env_vars_attr(&attr_str).collect::<Vec<_>>();
+
+        //* Then
+        assert_eq!(result, vec!["FOO"]);
+    }
+
+    #[test]
+    fn sanitize_multiple_env_vars() {
+        //* Given
+        let env_var1 = "FOO";
+        let env_var2 = "BAR";
+        let env_var3 = "BAZ";
+
+        let attr_str = format!("\t{},\n\t{},\n\t{}", env_var1, env_var2, env_var3);
+
+        //* When
+        let result = sanitize_env_vars_attr(&attr_str).collect::<Vec<_>>();
+
+        //* Then
+        assert_eq!(result, vec!["FOO", "BAR", "BAZ"]);
+    }
+
+    #[test]
+    fn sanitize_env_vars_with_whitespace() {
+        //* Given
+        let env_var = "FOO BAR";
+
+        let attr_str = env_var.to_string();
+
+        //* When
+        let result = sanitize_env_vars_attr(&attr_str).collect::<Vec<_>>();
+
+        //* Then
+        assert_eq!(result, vec!["FOO BAR"]);
+    }
+}


### PR DESCRIPTION
# Context and problem description

The `test_with::env` and `test_with::no_env` macros fail to handle properly the following multiline env vars case:

```rust
#[test_with::env(
    IT_SOME_LONG_ENV_VAR_NAME_TEST_URL,
    IT_SOME_LONG_ENV_VAR_NAME_TEST_AUTH_TOKEN
)]
#[tokio::test]
async fn some_test() {}
```

This is problematic since it interferes with _rustfmt_, i.e., `cargo fmt` command automatically changes the long attribute lines in a multiline format.

A possible workaround would be to annotate the test with the `#[rustfmt::skip]` so the macro attributes are not laid out in separate lines:

```rust
#[rustfmt::skip]
#[test_with::env(IT_SOME_LONG_ENV_VAR_NAME_TEST_URL,IT_SOME_LONG_ENV_VAR_NAME_TEST_AUTH_TOKEN)]
#[tokio::test]
async fn some_test() {
```

# Proposed solution

To fix the issue, I introduced the `sanitize_env_vars_attr(...)` function that properly handles the macro attributes arguments, removing any whitespace character and obtaining a slice containing the sanitized environment variable names. 

Additionally, I added some unit tests covering the `check_env_condition`, `check_no_env_condition`, and `sanitize_env_vars_attr` functions.