### PR TITLE
fix: disable default-features on test-with-derive dependency

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-test-with-derive = { version = "=0.16.0", path = "../derive" }
+test-with-derive = { version = "=0.16.0", path = "../derive", default-features = false }
 
 reqwest = { version = "0.13", features = ["blocking"], optional = true }
 ping = { version = "0.7.1", optional = true }


### PR DESCRIPTION
## Problem

`test-with-derive` is declared as an unconditional dependency of `test-with` without `default-features = false`:

```toml
test-with-derive = { version = "=0.16.0", path = "../derive" }
```

This means `test-with-derive` is always compiled with its default features (`net`, `resource`, `user`, `executable`, `timezone`) regardless of what features the user selects for `test-with`.

A user who only needs the `executable` feature:

```toml
test-with = { version = "0.16.0", default-features = false, features = ["executable"] }
```

still ends up pulling in the full dependency tree of all default features, including `reqwest` → `aws-lc-rs`/`aws-lc-sys` (large C build), `sysinfo`, `ping`, `jni`, and others — adding ~70 extra entries to `Cargo.lock`.

## Fix

Add `default-features = false` to the `test-with-derive` dependency:

```toml
test-with-derive = { version = "=0.16.0", path = "../derive", default-features = false }
```

All features in `test-with` already forward to their corresponding `test-with-derive/<feature>` counterparts (e.g. `executable = ["test-with-derive/executable", "which"]`), so no feature wiring is missing.
The fix only prevents derive's default features from being unconditionally activated.

## Impact

- Users opting in to a subset of features now get only the dependencies they asked for
- No behaviour change for users with default features (all features still activate the same derive features as before)